### PR TITLE
Messing around with promptr and open-interpreter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -239,3 +239,5 @@ misc/
 
 # Ignore litellm_uuid.txt
 litellm_uuid.txt
+
+tmp/

--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ Open Interpreter is licensed under the MIT License. You are permitted to use, co
 
 <br>
 
+rm /Users/ferrislucas/Library/Application\ Support/Open\ Interpreter/config.yaml && poetry run interpreter --model huggingface/perlthoughts/openchat-3.5-1210-32k --api_base https://zrdp314pfnvdi8jq.us-east-1.aws.endpoints.huggingface.cloud --api_key $HUGGINGFACE_API_KEY --max_tokens 4000 --context_window 8192 --prompt="$(cat test.txt)"
 
 rm /Users/ferrislucas/Library/Application\ Support/Open\ Interpreter/config.yaml && poetry run interpreter --model huggingface/openchat/openchat-3.5-1210 --api_base https://fgk80h92g8d614u2.us-east-1.aws.endpoints.huggingface.cloud --api_key $HUGGINGFACE_API_KEY --max_tokens 4000 --context_window 8192 --prompt="$(cat test.txt)"
 

--- a/README.md
+++ b/README.md
@@ -394,3 +394,8 @@ Open Interpreter is licensed under the MIT License. You are permitted to use, co
 > — _OpenAI's Code Interpreter Release_
 
 <br>
+
+
+rm /Users/ferrislucas/Library/Application\ Support/Open\ Interpreter/config.yaml && poetry run interpreter --model huggingface/openchat/openchat-3.5-1210 --api_base https://fgk80h92g8d614u2.us-east-1.aws.endpoints.huggingface.cloud --api_key $HUGGINGFACE_API_KEY --max_tokens 4000 --context_window 8192 --prompt="$(cat test.txt)"
+
+rm /Users/ferrislucas/Library/Application\ Support/Open\ Interpreter/config.yaml && poetry run interpreter --model huggingface/codellama/CodeLlama-34b-Instruct-hf --api_base https://dkjqw259yyxgvft8.us-east-1.aws.endpoints.huggingface.cloud --api_key $HUGGINGFACE_API_KEY --max_tokens 4000 --context_window 16000 --prompt="$(cat test.txt)" 

--- a/interpreter/core/generate_system_message.py
+++ b/interpreter/core/generate_system_message.py
@@ -22,6 +22,7 @@ def generate_system_message(interpreter):
     #### Add dynamic components, like the user's OS, username, relevant procedures, etc
 
     system_message += "\n" + get_user_info_string()
+    return system_message
 
     if not interpreter.local and not interpreter.disable_procedures:
         try:

--- a/interpreter/core/llm/convert_to_coding_llm.py
+++ b/interpreter/core/llm/convert_to_coding_llm.py
@@ -15,7 +15,7 @@ def convert_to_coding_llm(text_llm, debug_mode=False):
         assert messages[0]["role"] == "system"
         messages[0][
             "message"
-        ] += "\nTo execute code on the user's machine, write a markdown code block. Specify the language after the ```. You will receive the output. Use any programming language."
+        ] #+= "\nTo execute code on the user's machine, write a markdown code block. Specify the language after the ```. You will receive the output."
 
         # Gaslight method (DISABLED):
         '''
@@ -95,7 +95,7 @@ def convert_to_coding_llm(text_llm, debug_mode=False):
 
                     # Default to python if not specified
                     if language == "":
-                        language = "python"
+                        language = "shell"
                     else:
                         # Removes hallucinations containing spaces or non letters.
                         language = "".join(char for char in language if char.isalpha())

--- a/interpreter/core/llm/setup_text_llm.py
+++ b/interpreter/core/llm/setup_text_llm.py
@@ -147,9 +147,15 @@ def setup_text_llm(interpreter):
         if interpreter.debug_mode:
             litellm.set_verbose = True
 
+        #if interpreter.local:
+        #    params["model"] = "huggingface/" + "codellama/CodeLlama-34b-Instruct-hf"
+        #    params["api_base"] = "https://dkjqw259yyxgvft8.us-east-1.aws.endpoints.huggingface.cloud"
+        #    params["api_key"] = os.environ.get('HUGGINGFACE_API_KEY')
+
         # Report what we're sending to LiteLLM
         if interpreter.debug_mode:
             print("Sending this to LiteLLM:", params)
+        print("Messages: ", params["messages"])
 
         return litellm.completion(**params)
 

--- a/interpreter/core/utils/convert_to_openai_messages.py
+++ b/interpreter/core/utils/convert_to_openai_messages.py
@@ -43,12 +43,12 @@ def convert_to_openai_messages(messages, function_calling=True):
                 )
             else:
                 if message["output"] == "No output":
-                    content = "The code above was executed on my machine. It produced no output. The command was successful."
+                    content = "The code above was executed successfully on my machine."
                 else:
                     content = (
-                        "Code output: "
+                        "Command output: "
                         + message["output"]
-                        + "\n\nIf the task is complete, you can move on to the next step."
+                        + "\n\nGiven the command output, state the plan and what we should do next."
                     )
 
                 new_messages.append(

--- a/interpreter/core/utils/convert_to_openai_messages.py
+++ b/interpreter/core/utils/convert_to_openai_messages.py
@@ -43,12 +43,12 @@ def convert_to_openai_messages(messages, function_calling=True):
                 )
             else:
                 if message["output"] == "No output":
-                    content = "The code above was executed on my machine. It produced no output. Was that expected?"
+                    content = "The code above was executed on my machine. It produced no output. The command was successful."
                 else:
                     content = (
                         "Code output: "
                         + message["output"]
-                        + "\n\nWhat does this output mean / what's next (if anything, or are we done)?"
+                        + "\n\nIf the task is complete, you can move on to the next step."
                     )
 
                 new_messages.append(

--- a/interpreter/core/utils/truncate_output.py
+++ b/interpreter/core/utils/truncate_output.py
@@ -1,4 +1,5 @@
 def truncate_output(data, max_output_chars=2000):
+    return data 
     needs_truncation = False
 
     message = f"Output truncated. Showing the last {max_output_chars} characters.\n\n"

--- a/interpreter/core/utils/truncate_output.py
+++ b/interpreter/core/utils/truncate_output.py
@@ -1,5 +1,5 @@
 def truncate_output(data, max_output_chars=2000):
-    return data 
+    #return data 
     needs_truncation = False
 
     message = f"Output truncated. Showing the last {max_output_chars} characters.\n\n"

--- a/interpreter/terminal_interface/config.yaml
+++ b/interpreter/terminal_interface/config.yaml
@@ -34,12 +34,15 @@ system_message: |
   
   Any shell or code that you display will stop your sentence, and the code will be executed immediately.
   Only display code that you're trying to execute.
+  Only display code if you intend to execute it.
 
-  To execute code on the user's machine, write a markdown code block. 
-  Specify the language after the ```. 
+  To execute a shell command on the user's machine, write a markdown code block. 
   You will receive the output of the shell command.
   Your initial state is at a bash shell prompt.
   You can only execute shell commands - you cannot use interactive shell commands. 
+
+  Assume the shell command was successful if the shell command has no output.
+  It is your responsibility to execute commands by displaying them in a code block.
 
 local: false
 model: "gpt-4"

--- a/interpreter/terminal_interface/config.yaml
+++ b/interpreter/terminal_interface/config.yaml
@@ -9,6 +9,22 @@ system_message: |
   Write messages to the user in Markdown.
   In general, try to **make plans** with as few steps as possible. As for actually executing code to carry out that plan, for *stateful* languages (like python, javascript, shell, but NOT for html which starts from 0 every time) **it's critical not to try to do everything in one code block.** You should try something, print information about it, then continue from there in tiny, informed steps. You will never get it on the first try, and attempting it in one go will often lead to errors you cant see.
   You are capable of **any** task.
+  
+  Use bash for directory navigation, always cd into the project's root folder before each command.
+  
+  Take notes on significant findings in a notes.md file in the project root.
+  Consult this file before planning each step - the file can change between steps and sessions, so check its contents before every step.
+  The notes should include useful commands that you would like to remember between sessions - for example, what command works to run the tests.  
+
+  It's important to use promptr when creating, modifying, or configuring source code.
+  The promptr CLI tool is extremely useful for working with source code at a conceptual level.
+  Instructions for using promptr in to create, modify, and configure source code:
+  - provide a prompt with the -p argument, for example: `promptr -p "write tests for the controller at path/x/y/z place tests at path/x/y/z"`
+  - The promptr cli tool reports time elapsed on success. It does not display file contents.
+  - Give promptr instructions as if you're giving instructions to a junior software engineer.
+  - promptr requires the paths to any files that would be needed to understand and accomplish the task.
+  - very often, you will need to provide promptr with multiple files - for example, when creating tests provide the test path as well as any relevant production code file paths
+
 local: false
 model: "gpt-4"
 temperature: 0

--- a/interpreter/terminal_interface/config.yaml
+++ b/interpreter/terminal_interface/config.yaml
@@ -1,29 +1,45 @@
 system_message: |
-  You are Open Interpreter, a world-class programmer that can complete any goal by executing code.
-  First, write a plan. **Always recap the plan between each code block** (you have extreme short-term memory loss, so you need to recap the plan between each message block to retain it).
-  When you execute code, it will be executed **on the user's machine**. The user has given you **full and complete permission** to execute any code necessary to complete the task.
-  If you want to send data between programming languages, save the data to a txt or json.
-  You can access the internet. Run **any code** to achieve the goal, and if at first you don't succeed, try again and again.
-  You can install new packages.
-  When a user refers to a filename, they're likely referring to an existing file in the directory you're currently executing code in.
+  You are Open Interpreter, a world-class shell script programmer that can complete any goal by executing code.
+  First, write a plan. 
   Write messages to the user in Markdown.
-  In general, try to **make plans** with as few steps as possible. As for actually executing code to carry out that plan, for *stateful* languages (like python, javascript, shell, but NOT for html which starts from 0 every time) **it's critical not to try to do everything in one code block.** You should try something, print information about it, then continue from there in tiny, informed steps. You will never get it on the first try, and attempting it in one go will often lead to errors you cant see.
+  In general, try to **make plans** with as few steps as possible. 
+  
+  As for actually executing shell commands to carry out that plan:
+  **it's critical not to try to do everything in one code block.** 
+  **you can specify a cd command as well as one additional command per code block.** 
+  
+  You should try something, print information about it, then continue from there in tiny, informed steps. 
   You are capable of **any** task.
-  
-  Use bash for directory navigation, always cd into the project's root folder before each command.
-  
-  Take notes on significant findings in a notes.md file in the project root.
-  Consult this file before planning each step - the file can change between steps and sessions, so check its contents before every step.
-  The notes should include useful commands that you would like to remember between sessions - for example, what command works to run the tests.  
 
+  You have two capabilities:
+  - executing shell commands
+  - creating, modifying, and configuring source code and systems using the promptr CLI tool.
+
+  Use shell for directory navigation.
+  Use shell or promptr for all tasks - assume all calls to promptr are successful.
+
+  The promptr CLI tool is extremely useful for modifying source code.
+  You can instruct promptr with conceptual instructions in order to create and modify source code.
   It's important to use promptr when creating, modifying, or configuring source code.
-  The promptr CLI tool is extremely useful for working with source code at a conceptual level.
+  Promptr can only create and modify source code files. 
+  Promptr outputs the time it takes to run a command, and does not display file contents.
   Instructions for using promptr in to create, modify, and configure source code:
   - provide a prompt with the -p argument, for example: `promptr -p "write tests for the controller at path/x/y/z place tests at path/x/y/z"`
   - The promptr cli tool reports time elapsed on success. It does not display file contents.
   - Give promptr instructions as if you're giving instructions to a junior software engineer.
   - promptr requires the paths to any files that would be needed to understand and accomplish the task.
   - very often, you will need to provide promptr with multiple files - for example, when creating tests provide the test path as well as any relevant production code file paths
+  - promptr can only operate on files in the current directory, so you will need to cd into the project's root folder before each command.
+  - always give promptr conceptual instructions, not actual source code
+  
+  Any shell or code that you display will stop your sentence, and the code will be executed immediately.
+  Only display code that you're trying to execute.
+
+  To execute code on the user's machine, write a markdown code block. 
+  Specify the language after the ```. 
+  You will receive the output of the shell command.
+  Your initial state is at a bash shell prompt.
+  You can only execute shell commands - you cannot use interactive shell commands. 
 
 local: false
 model: "gpt-4"

--- a/interpreter/terminal_interface/start_terminal_interface.py
+++ b/interpreter/terminal_interface/start_terminal_interface.py
@@ -110,6 +110,12 @@ arguments = [
         "help_text": "experimentally use vision for supported languages (HTML)",
         "type": bool,
     },
+    {
+        "name": "prompt",
+        "nickname": "p",
+        "help_text": "provide an initial prompt for the language model",
+        "type": str,
+    }
 ]
 
 
@@ -302,4 +308,5 @@ Once the server is running, you can begin your conversation below.
 
     validate_llm_settings(interpreter)
 
-    interpreter.chat()
+    prompt = args.prompt
+    interpreter.chat(message=prompt)

--- a/interpreter/terminal_interface/start_terminal_interface.py
+++ b/interpreter/terminal_interface/start_terminal_interface.py
@@ -206,7 +206,9 @@ def start_terminal_interface(interpreter):
 
     if args.local:
         # Default local (LM studio) attributes
-        interpreter.system_message = "You are an AI."
+        
+        # this line must be commented out or the system message from config is replaced here
+        #interpreter.system_message = "You are an AI."
         interpreter.model = (
             "openai/" + interpreter.model
         )  # This tells LiteLLM it's an OpenAI compatible server
@@ -309,4 +311,6 @@ Once the server is running, you can begin your conversation below.
     validate_llm_settings(interpreter)
 
     prompt = args.prompt
+    #print(interpreter.system_message)
+    #raise('test')
     interpreter.chat(message=prompt)

--- a/interpreter/terminal_interface/terminal_interface.py
+++ b/interpreter/terminal_interface/terminal_interface.py
@@ -239,6 +239,9 @@ def terminal_interface(interpreter, message):
                 # Don't loop
                 break
 
+            # end instead of looping
+            break
+
         except KeyboardInterrupt:
             # Exit gracefully
             if active_block:

--- a/interpreter/terminal_interface/terminal_interface.py
+++ b/interpreter/terminal_interface/terminal_interface.py
@@ -240,7 +240,7 @@ def terminal_interface(interpreter, message):
                 break
 
             # end instead of looping
-            break
+            #break
 
         except KeyboardInterrupt:
             # Exit gracefully


### PR DESCRIPTION
This PR makes Open Interpreter aware of the [Promptr CLI tool](https://github.com/ferrislucas/promptr). 

The intention is to use Open Interpreter as a code agent that takes the path to a file containing an initial prompt. From there, Open Interpreter does its best to service the request in the initial prompt. Open Interpreter is supposed to use Promptr for any code related tasks.

This is not production ready. It's an experiment. 

Use at your own risk.